### PR TITLE
Fix ClassNotFoundException with proguard on.

### DIFF
--- a/crashyreporter/src/main/java/com/crazylegend/crashyreporter/initializer/CrashyInitializer.kt
+++ b/crashyreporter/src/main/java/com/crazylegend/crashyreporter/initializer/CrashyInitializer.kt
@@ -1,6 +1,7 @@
 package com.crazylegend.crashyreporter.initializer
 
 import android.content.Context
+import androidx.annotation.Keep
 import androidx.startup.Initializer
 import com.crazylegend.crashyreporter.CrashyReporter
 
@@ -8,6 +9,7 @@ import com.crazylegend.crashyreporter.CrashyReporter
 /**
  * Created by crazy on 6/18/20 to long live and prosper !
  */
+@Keep
 internal class CrashyInitializer : Initializer<CrashyInitializer.CrashyToken> {
 
     object CrashyToken


### PR DESCRIPTION
Fix problems like:
```
java.lang.RuntimeException: Unable to get provider androidx.startup.InitializationProvider: b.w.d: java.lang.ClassNotFoundException: com.crazylegend.crashyreporter.initializer.CrashyInitializer
```

Could be done with this rule too: `-keep class com.crazylegend.crashyreporter.initializer.CrashyInitializer`